### PR TITLE
cambio sugerido para verificar la ortogonalidad de 2 vectores

### DIFF
--- a/temas/III.computo_matricial/3.3.d.SVD.ipynb
+++ b/temas/III.computo_matricial/3.3.d.SVD.ipynb
@@ -653,7 +653,7 @@
     "\n",
     "    * ¿Cómo reviso si las columnas  $i,j$ de $A^{(k)}$ son ortogonales?  si se cumple que\n",
     "\n",
-    "$$\\frac{a_i^{T (k)}a_j^{(k)}}{||a_i^{(k)}||_2||a_j^{(k)}||_2} < TOL$$\n",
+    "$$\\frac{signo(a_i^{T (k)}a_j^{(k)})}{||a_i^{(k)}||_2||a_j^{(k)}||_2} < TOL$$\n",
     "\n",
     "con $TOL$ un valor menor o igual a $10^{-8}$ entonces son ortogonales las columnas $a_i^{(k)}, a_j^{(k)}$ de $A^{(k)}$.\n",
     "\n",
@@ -751,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
El motivo del pull request es para sugerir se agregue la función signo cuando se hace el producto punto de 2 vectores en el críterio para verificar ortogonalidad de entre ellos utilizando una tolerancia dada. Lo anterior dado que se pueden tener 2 vectores paralelos siendo el segundo de la forma vector2 = (- escalar)*vector1, pues **su producto punto será negativo**  (menor a la tolerancia fijada), es decir, se está cumpliendo el criterio, no obstante los vectores no son ortogonales