### PR TITLE
Typo en definición de matriz

### DIFF
--- a/libro_optimizacion/temas/1.computo_cientifico/1.3/Normas_vectoriales_y_matriciales.ipynb
+++ b/libro_optimizacion/temas/1.computo_cientifico/1.3/Normas_vectoriales_y_matriciales.ipynb
@@ -390,7 +390,7 @@
     "a_{n1} &a_{n2}&\\dots&a_{nn}\\\\\n",
     "\\vdots &\\vdots& \\vdots&\\vdots\\\\\n",
     "a_{m-11} &a_{m-12}&\\dots&a_{m-1n}\\\\\n",
-    "a_{m1} &a_{m2}&\\dots&a_{mm}\n",
+    "a_{m1} &a_{m2}&\\dots&a_{mn}\n",
     "\\end{array}\n",
     "\\right] \n",
     "$$\n",


### PR DESCRIPTION
Se corrige el subíndice mm ---> mn en definición de una matriz del Ejemplo